### PR TITLE
컴포넌트 스캔 필터 실습

### DIFF
--- a/src/test/java/com/example/exbasicspring/scan/BeanA.java
+++ b/src/test/java/com/example/exbasicspring/scan/BeanA.java
@@ -1,0 +1,5 @@
+package com.example.exbasicspring.scan;
+
+@MyIncludeComponent
+public class BeanA {
+}

--- a/src/test/java/com/example/exbasicspring/scan/BeanB.java
+++ b/src/test/java/com/example/exbasicspring/scan/BeanB.java
@@ -1,0 +1,5 @@
+package com.example.exbasicspring.scan;
+
+@MyExcludeComponent
+public class BeanB {
+}

--- a/src/test/java/com/example/exbasicspring/scan/ComponentScanFilterTest.java
+++ b/src/test/java/com/example/exbasicspring/scan/ComponentScanFilterTest.java
@@ -1,0 +1,37 @@
+package com.example.exbasicspring.scan;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class ComponentScanFilterTest {
+
+    @Test
+    void filterTest() {
+        ApplicationContext ac = new AnnotationConfigApplicationContext(TestAppConfig.class);
+
+        BeanA beanA = ac.getBean("beanA", BeanA.class);
+        assertThat(beanA).isNotNull();
+
+        assertThrows(
+                NoSuchBeanDefinitionException.class,
+                () -> ac.getBean("beanB", BeanB.class)
+        );
+    }
+
+    @ComponentScan(
+            includeFilters = @ComponentScan.Filter(type = FilterType.ANNOTATION, classes = MyIncludeComponent.class),
+            excludeFilters = @ComponentScan.Filter(type = FilterType.ANNOTATION, classes = MyExcludeComponent.class)
+    )
+    @Configuration
+    static class TestAppConfig {
+    }
+}

--- a/src/test/java/com/example/exbasicspring/scan/MyExcludeComponent.java
+++ b/src/test/java/com/example/exbasicspring/scan/MyExcludeComponent.java
@@ -1,0 +1,9 @@
+package com.example.exbasicspring.scan;
+
+import java.lang.annotation.*;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface MyExcludeComponent {
+}

--- a/src/test/java/com/example/exbasicspring/scan/MyIncludeComponent.java
+++ b/src/test/java/com/example/exbasicspring/scan/MyIncludeComponent.java
@@ -1,0 +1,9 @@
+package com.example.exbasicspring.scan;
+
+import java.lang.annotation.*;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface MyIncludeComponent {
+}


### PR DESCRIPTION
컴포넌트 스캔 대상을 필터에 포함하거나, 제외시키는 실습을 해 보았다.

'@includeFilters' -> BeanA class, '@excludeFilters' -> BeanB class 적용했다.

테스트용 Configuration class 를 생성해 includeFilters, excludeFilters 를 적용해, 컴포넌트 스캔 필터가 동작하는 것을 공부했다.

This closes #26 
 
